### PR TITLE
Added minimum requirements for packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-
 *.pyc
 *.gpkg
+*.egg-info
+dist/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel"
+]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+from setuptools import setup
+import os
+
+with open(os.path.join(os.path.dirname(__file__), 'README.md')) as readme:
+    README = readme.read()
+
+setup(
+    name='pygeopkg',
+    version='0.1',
+    # author='Author',
+    # author_email='author@email.com',
+    description='A Python library that allows for the creation and population of OGC GeoPackage databases with write access',
+    long_description=README,
+    long_description_content_type='text/markdown',
+    url='https://github.com/realiii/pygeopkg',
+    classifiers=[
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
+        # 'Development Status :: 5 - Production/Stable',
+    ],
+    packages=['conversion', 'core', 'resources', 'shared'],
+)


### PR DESCRIPTION
These additional files are required to build the project for upload to the Python Package Index. Some metadata fields in `setup.py` (author, author_email, etc.) have been left commented out. When these have been updated (if required), the project can be built with `python -m build` and then uploaded to Pypi.