### PR TITLE
Create GeoPackage geometry from WKB data from PostGIS

### DIFF
--- a/pygeopkg/conversion/to_geopkg_geom.py
+++ b/pygeopkg/conversion/to_geopkg_geom.py
@@ -192,5 +192,15 @@ def point_lists_to_gpkg_multi_polygon(header, list_of_polys):
 # End point_lists_to_gpkg_multi_polygon function
 
 
+def postgis_wkb_to_gpkg_geometry(header, wkb):
+    """
+    This accepts a WKB object from PostGIS created with ST_AsBinary()
+    :param header: the binary header, see "make_gpkg_geom_header"
+    :param wkb: wkb object
+    :return:
+    """
+    return buffer(header + wkb)
+
+
 if __name__ == '__main__':
     pass

--- a/pygeopkg/conversion/to_geopkg_geom.py
+++ b/pygeopkg/conversion/to_geopkg_geom.py
@@ -192,7 +192,7 @@ def point_lists_to_gpkg_multi_polygon(header, list_of_polys):
 # End point_lists_to_gpkg_multi_polygon function
 
 
-def postgis_wkb_to_gpkg_geometry(header, wkb):
+def wkb_to_gpkg_geometry(header, wkb):
     """
     This accepts a WKB object from PostGIS created with ST_AsBinary()
     :param header: the binary header, see "make_gpkg_geom_header"


### PR DESCRIPTION
Added a function that takes WKB data from PostGIS and header and creates a geopackage geometry. Only tested with PostGIS. You can simply pass the binary data and prepend the header and it works in QGIS and passes validation. Use ST_AsBinary() to convert geometry to WKB.

